### PR TITLE
Added possibility for providing an alternative config file for fig.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,13 @@ Note: If you recreates the VM ( for instance by doing ```vagrant destroy```, you
 If you later just want to recreate specific images or containers, you then first remove those using `docker rm [container]` and `docker rmi [image]`, and then run
 `fig.sh up -d --no-recreate`
 
-fig.sh is a wrapper for fig which also do some internal provisioning. Any command line arguments used when starting the wrapper is passed on to fig.
+
+### fig.sh
+
+fig.sh is a wrapper for fig which also do some internal provisioning. Any command line arguments (except "-c configfile" ) used when starting the wrapper is passed on to fig.
+fig.sh also accepts one special argument for specifying a alternative configuration file ( files/fig.config is the default one if "-c ..." is not provided ).
+Example : 
+```fig.sh -c files/my_customer_fig.config up -d --no-recreate```
 
 ### Access your eZ Publish installation
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ If you later just want to recreate specific images or containers, you then first
 fig.sh is a wrapper for fig which also do some internal provisioning. Any command line arguments (except "-c configfile" ) used when starting the wrapper is passed on to fig.
 fig.sh also accepts one special argument for specifying a alternative configuration file ( files/fig.config is the default one if "-c ..." is not provided ).
 Example : 
-```fig.sh -c files/my_customer_fig.config up -d --no-recreate```
+```fig.sh -c files/my_custom_fig.config up -d --no-recreate```
 
 ### Access your eZ Publish installation
 

--- a/fig_ezpinstall.sh
+++ b/fig_ezpinstall.sh
@@ -1,12 +1,37 @@
 #!/bin/bash
 
 export FIG_PROJECT_NAME=ezpublishdocker
+CONFIGFILE=files/fig.config
+CMDPARAMETERS="$@"
+
+# Check for parameter "-c alternative-config.file.config"
+function set_figconfig
+{
+    local value
+    value=0
+
+    for i in "$@"; do
+        if [ $i == "-c" ]; then
+            value=1
+            continue
+        fi
+        if [ $value == 1 ]; then
+            value=0
+            CONFIGFILE=$i
+            echo Config file overriden. Using $CONFIGFILE instead
+            continue
+        fi
+        CMDPARAMETERS="$CMDPARAMETERS $i"
+    done
+}
+
+set_figconfig "$@"
 
 # Load default settings
 source files/fig.config-EXAMPLE
 
 # Load custom settings
-source files/fig.config
+source $CONFIGFILE
 
 if [ -f files/auth.json ]; then
     cp files/auth.json dockerfiles/ezpublish/install


### PR DESCRIPTION
It is convenient to have multiple fig.config files lying around. This PR makes it possible to have that without having to manually copy them ( overwriting files/fig.config ) before you execute fig.sh