### PR TITLE
Add seperate script for building service images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ files/auth.json
 files/user-data
 files/docker-compose.config
 files/distro_containers.config
+files/kickstart_template.ini
 volumes/mysql
 volumes/ezpublish
 volumes/composercache

--- a/build.sh
+++ b/build.sh
@@ -38,6 +38,12 @@ function tag
     docker tag -f ${COMPOSE_PROJECT_NAME}_ezphp:latest ezsystems/ezphp:latest
 }
 
+function remove_project_tags
+{
+    docker rmi ${COMPOSE_PROJECT_NAME}_web
+    docker rmi ${COMPOSE_PROJECT_NAME}_ezphp
+}
+
 set_composeconfig "$@"
 
 # Load default settings
@@ -56,3 +62,4 @@ fi
 
 build
 tag
+remove_project_tags

--- a/build.sh
+++ b/build.sh
@@ -29,7 +29,7 @@ function set_composeconfig
 
 function build
 {
-    ./docker-compose.sh $CONFIGFILEPARAM -f docker-compose_build.yml build
+    ./docker-compose.sh $CONFIGFILEPARAM -f docker-compose_build.yml build --no-cache
 }
 
 function tag

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+export COMPOSE_PROJECT_NAME=ezpublishdocker
+CONFIGFILE=files/docker-compose.config
+CMDPARAMETERS="$@"
+
+# Check for parameter "-c alternative-config.file.config"
+function set_composeconfig
+{
+    local value
+    value=0
+
+    CMDPARAMETERS=""
+
+    for i in "$@"; do
+        if [ $i == "-c" ]; then
+            value=1
+            continue
+        fi
+        if [ $value == 1 ]; then
+            value=0
+            CONFIGFILE=$i
+            echo Config file overriden. Using $CONFIGFILE instead
+            continue
+        fi
+        CMDPARAMETERS="$CMDPARAMETERS $i"
+    done
+}
+
+function build
+{
+    ./docker-compose.sh $CONFIGFILEPARAM -f docker-compose_build.yml build
+}
+
+function tag
+{
+    docker tag -f ${COMPOSE_PROJECT_NAME}_web:latest ezsystems/web:latest
+    docker tag -f ${COMPOSE_PROJECT_NAME}_ezphp:latest ezsystems/ezphp:latest
+}
+
+set_composeconfig "$@"
+
+# Load default settings
+source files/docker-compose.config-EXAMPLE
+
+# Load custom settings
+source $CONFIGFILE
+
+if [ $CONFIGFILE == "files/docker-compose.config" ]; then
+    CONFIGFILEPARAM=""
+else
+    CONFIGFILEPARAM="-c $CONFIGFILE "
+fi
+
+
+
+build
+tag

--- a/create_distro_containers.sh
+++ b/create_distro_containers.sh
@@ -108,11 +108,6 @@ function prepare
     docker rmi ${COMPOSE_PROJECT_NAME}_databasedump:latest || /bin/true
     docker rmi ${DOCKER_REPOSITORY}/${DOCKER_USER}/${BUILD_TARGET}_databasedump:${DOCKER_BUILDVER} || /bin/true
 
-    docker rmi ${COMPOSE_PROJECT_NAME}_ezphp || /bin/true
-    docker rmi ${COMPOSE_PROJECT_NAME}_web1 || /bin/true
-    docker rmi ${COMPOSE_PROJECT_NAME}_db1 || /bin/true
-    docker rmi ${COMPOSE_PROJECT_NAME}_phpfpm1 || /bin/true
-
 
     if [ $REBUILD_EZP == "true" ]; then
         sudo rm -rf volumes/ezpublish volumes/mysql || /bin/true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ db1:
 
 phpfpm1:
   # docker compose does not allow to specify container name, this is what it generates, might be fixed in 1.3
-  build: dockerfiles/ezphp
+  image: ezsystems/ezphp
   links:
    - db1:db
   volumes_from:
@@ -40,7 +40,7 @@ phpfpm1:
    - MYSQL_PASSWORD
 
 web1:
-  build: dockerfiles/internal/nginx
+  image: ezsystems/web
   links:
    - phpfpm1:php_fpm
   volumes_from:

--- a/docker-compose_build.yml
+++ b/docker-compose_build.yml
@@ -1,0 +1,6 @@
+
+ezphp:
+  build: dockerfiles/ezphp
+
+web:
+  build: dockerfiles/internal/nginx

--- a/docker-compose_ezpinstall.sh
+++ b/docker-compose_ezpinstall.sh
@@ -38,11 +38,8 @@ if [ ! -f files/auth.json ]; then
     touch files/auth.json
 fi
 
-# Copy kickstart template to build dir
-if [ "$EZ_KICKSTART_FROM_TEMPLATE" != "" ]; then
-    cp files/$EZ_KICKSTART_FROM_TEMPLATE dockerfiles/ezphp/kickstart_template.ini
-else
-    echo "# Kickstart file not found. Please check your kickstart settings ( like EZ_KICKSTART_FROM_TEMPLATE ) in config/docker-compose.config if you want a kickstart file " > dockerfiles/ezphp/kickstart_template.ini
+if [ ! -f files/kickstart_template.ini ]; then
+    touch files/kickstart_template.ini
 fi
 
 # If {COMPOSE_EXECUTION_PATH} is not set and docker-compose is not in path, we'll test if it is located in /opt/bin. Needed for systemd service

--- a/docker-compose_ezpinstall.sh
+++ b/docker-compose_ezpinstall.sh
@@ -61,6 +61,7 @@ ${COMPOSE_EXECUTION_PATH}docker-compose -f $YMLFILE up --no-recreate
 if [ ! -f volumes/ezpublish/composer.json ]; then
     echo "No prior install detected in ezpublish folder, so running Composer with: composer --no-interaction create-project ${EZ_COMPOSERPARAM?}"
     ${COMPOSE_EXECUTION_PATH}docker-compose -f $YMLFILE run --rm ezphp composer --no-interaction create-project --no-progress ${EZ_COMPOSERPARAM?};
+    ${COMPOSE_EXECUTION_PATH}docker-compose -f $YMLFILE rm -v -f composercachevol ezphp
 else
     echo "Prior install detected in ezpublish folder, skipp running Composer"
 fi

--- a/docker-compose_ezpinstall.yml
+++ b/docker-compose_ezpinstall.yml
@@ -17,5 +17,6 @@ ezphp:
    - composercachevol
   volumes:
    - ./files/auth.json:/var/.composer/auth.json
+   - ./files/kickstart_template.ini:/kickstart_template.ini
    # Override command, we don't want to start php-fpm just yet, just want to run composer commands this
   command: php -v

--- a/docker-compose_ezpinstall.yml
+++ b/docker-compose_ezpinstall.yml
@@ -11,7 +11,7 @@ composercachevol:
    - ./volumes/composercache:/var/.composer/cache
 
 ezphp:
-  build: dockerfiles/ezphp
+  image: ezsystems/ezphp
   volumes_from:
    - ezpublishvol
    - composercachevol

--- a/docker-compose_services.yml
+++ b/docker-compose_services.yml
@@ -25,7 +25,7 @@ site1db1:
 
 site1phpfpm1:
   # docker compose does not allow to specify container name, this is what it generates, might be fixed in 1.3
-  image: ezpublishdocker_ezphp
+  image: ezsystems/ezphp
   links:
    - site1db1:db
   volumes_from:
@@ -38,7 +38,7 @@ site1phpfpm1:
   restart: always
 
 site1web1:
-  image: ezpublishdocker_web1
+  image: ezsystems/web
   links:
    - site1phpfpm1:php_fpm
   volumes_from:
@@ -53,7 +53,7 @@ site1web1:
   restart: always
 
 site1initialize:
-  image: ezpublishdocker_ezphp
+  image: ezsystems/ezphp
   links:
    - site1db1:db
   volumes_from:

--- a/dockerfiles/ezphp/Dockerfile
+++ b/dockerfiles/ezphp/Dockerfile
@@ -65,7 +65,6 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 # As application is put in as volume we do all needed operation on run
 ADD run.sh /run.sh
 ADD generate_kickstart_file.sh /generate_kickstart_file.sh
-ADD kickstart_template.ini /kickstart_template.ini
 ADD generate_parameters_file.sh /generate_parameters_file.sh
 ADD prepare_distribution_volume.sh /prepare_distribution_volume.sh
 ADD config/opcache.ini /etc/php5/mods-available/opcache.ini


### PR DESCRIPTION
With this PR, the process of setting up the system is split basically into 3 parts
 - Build the service images ( php and nginx ) ( build.sh )
 - Download and install eZ Platform ( docker-compose_ezpinstall.sh )
 - Create the containers ( docker-compose.sh up -d --no-recreate )


