### PR TITLE
Removed solr from default setup. It can instead be opted in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.vagrant/
 docker-compose_behat.yml
+docker-compose_solr.yml
 files/vagrant.yml
 files/authorized_keys2
 files/auth.json

--- a/README.md
+++ b/README.md
@@ -300,3 +300,27 @@ Run the eZ Platform/Studio install script, example:
 
 Run behat tests, example:
     ```./docker-compose.sh -f docker-compose_behat.yml run --rm behatphpcli bin/behat --no-colors --profile demo --suite content```
+
+
+#### Running eZ Platform/Studio with solr
+
+Make a config file ( recommended, but not strictly speaking )
+    ```cp files/docker-compose.config-EXAMPLE files/docker-compose.config```
+
+Make docker-compose file for solr:
+    ```cat docker-compose.yml docker-compose_solr.yml.template > docker-compose_solr.yml```
+
+Enable solr link for phpfpm1 service
+    Edit `docker-compose_solr.yml` and uncomment `#   - solr1:solr` in the `phpfpm1:` section.
+
+Create the service images ( web and php images )
+    ```./build.sh```
+
+Install eZ Platform/Studio:
+    ```./docker-compose_ezpinstall.sh```
+
+Create the containers needed for running eZ Platform/Studio
+    ```./docker-compose.sh -f docker-compose_solr.yml up -d --no-recreate```
+
+Run the install script
+    ```docker-compose -f docker-compose_solr.yml run --rm phpfpm1 /bin/bash -c "php ezpublish/console ezplatform:install demo; php ezpublish/console cache:clear --env=prod"```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,20 +26,12 @@ db1:
    - MYSQL_DATABASE=ezp
    - TERM=dumb
 
-solr1:
-  image: makuk66/docker-solr:4.10.4
-  volumes_from:
-    - ezpublishvol
-  command: /bin/bash -c "cp -R /var/www/vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/* /opt/solr/example/solr/collection1/conf/
-    && /opt/solr/bin/solr start -f"
-
-
 phpfpm1:
   # docker compose does not allow to specify container name, this is what it generates, might be fixed in 1.3
   image: ezsystems/ezphp
   links:
    - db1:db
-   - solr1:solr
+#   - solr1:solr
   volumes_from:
    - ezpublishvol
   environment:

--- a/docker-compose_solr.yml.template
+++ b/docker-compose_solr.yml.template
@@ -1,0 +1,8 @@
+
+solr1:
+  image: makuk66/docker-solr:4.10.4
+  volumes_from:
+    - ezpublishvol
+  command: /bin/bash -c "cp -R /var/www/vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/* /opt/solr/example/solr/collection1/conf/
+    && /opt/solr/bin/solr start -f"
+


### PR DESCRIPTION
This PR changes to that solr is not enabled to default.

Solr has currently the following drawbacks
 - solr don't store data in volume on host 
 - create_distro_containers.sh do not create a image storing solr data

This should be fixed before enabling solr by default