### PR TITLE
Fixed so that all PHP scripts are executed as www-data instead of root

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ When the containers are created, you should be able to browse to eZ Platform set
 ### Setting up eZ Platform using install script
 
 It is possible to setup a fresh installation using the install script instead of using the setup wizard. ( If using vagrant, this is done automaticly )
- - Run command : ```docker-compose -f docker-compose.yml run --rm phpfpm1 /bin/bash -c "php ezpublish/console ezplatform:install demo; php ezpublish/console cache:clear --env=prod"```
+ - Run command : ```docker-compose -f docker-compose.yml run -u ez --rm phpfpm1 /bin/bash -c "php ezpublish/console ezplatform:install demo; php ezpublish/console cache:clear --env=prod"```
 
 FYI : The command above assumes you have ```EZ_ENVIRONMENT=prod``` in files/docker-compose.config. If you use a different setting, adjust the ```--env=....``` parameter accordingly.
 You may also substitute "demo" with "demo_clean" if you want to install ezdemo without demo data, or "clean" if only want the very basics.
@@ -240,7 +240,7 @@ Create the containers needed for running eZ Platform/Studio
     ```./docker-compose.sh up -d --no-recreate```
 
 Run the install script
-    ```docker-compose -f docker-compose.yml run --rm phpfpm1 /bin/bash -c "php ezpublish/console ezplatform:install demo; php ezpublish/console cache:clear --env=prod"```
+    ```docker-compose -f docker-compose.yml run --rm -u ez phpfpm1 /bin/bash -c "php ezpublish/console ezplatform:install demo; php ezpublish/console cache:clear --env=prod"```
 
 Stop the containers:
     ```docker-compose -f docker-compose.yml stop```
@@ -296,7 +296,7 @@ Create the containers needed for running eZ Platform/Studio
     ```./docker-compose.sh -f docker-compose_behat.yml up -d --no-recreate```
 
 Run the eZ Platform/Studio install script, example:
-    ```docker-compose -f docker-compose_behat.yml run --rm phpfpm1 /bin/bash -c "php ezpublish/console ezplatform:install demo; php ezpublish/console cache:clear --env=prod"```
+    ```docker-compose -f docker-compose_behat.yml run -u ez --rm phpfpm1 /bin/bash -c "php ezpublish/console ezplatform:install demo; php ezpublish/console cache:clear --env=prod"```
 
 Run behat tests, example:
     ```./docker-compose.sh -f docker-compose_behat.yml run --rm behatphpcli bin/behat --no-colors --profile demo --suite content```
@@ -323,4 +323,4 @@ Create the containers needed for running eZ Platform/Studio
     ```./docker-compose.sh -f docker-compose_solr.yml up -d --no-recreate```
 
 Run the install script
-    ```docker-compose -f docker-compose_solr.yml run --rm phpfpm1 /bin/bash -c "php ezpublish/console ezplatform:install demo; php ezpublish/console cache:clear --env=prod"```
+    ```docker-compose -f docker-compose_solr.yml run -u ez --rm phpfpm1 /bin/bash -c "php ezpublish/console ezplatform:install demo; php ezpublish/console cache:clear --env=prod"```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -120,8 +120,8 @@ Vagrant.configure("2") do |config|
           echo "Now waiting 20 seconds for database and Solr to be fully booted before installing eZ Platform data!"
           sleep 20
           echo "Install eZ Platform demo data"
-          ${COMPOSE_EXECUTION_PATH}docker-compose -f docker-compose.yml run --rm phpfpm1 /bin/bash -c "php ezpublish/console --env=$EZ_ENVIRONMENT ezplatform:install demo; php ezpublish/console cache:clear --env=$EZ_ENVIRONMENT"
-          ${COMPOSE_EXECUTION_PATH}docker-compose -f docker-compose.yml run --rm phpfpm1 /bin/bash -c "php ezpublish/console cache:warmup --env=$EZ_ENVIRONMENT"
+          ${COMPOSE_EXECUTION_PATH}docker-compose -f docker-compose.yml run -u ez --rm phpfpm1 /bin/bash -c "php ezpublish/console --env=$EZ_ENVIRONMENT ezplatform:install demo; php ezpublish/console cache:clear --env=$EZ_ENVIRONMENT"
+          ${COMPOSE_EXECUTION_PATH}docker-compose -f docker-compose.yml run -u ez --rm phpfpm1 /bin/bash -c "php ezpublish/console cache:warmup --env=$EZ_ENVIRONMENT"
       fi
     '
   end

--- a/create_distro_containers.sh
+++ b/create_distro_containers.sh
@@ -164,13 +164,13 @@ function run_installscript
     sleep 12
 
     if [ $REBUILD_EZP == "true" ]; then
-        ${COMPOSE_EXECUTION_PATH}docker-compose -f $MAINCOMPOSE run --rm phpfpm1 /bin/bash -c "php ezpublish/console --env=prod ezplatform:install demo && php ezpublish/console cache:clear --env=prod"
+        ${COMPOSE_EXECUTION_PATH}docker-compose -f $MAINCOMPOSE run -u ez --rm phpfpm1 /bin/bash -c "php ezpublish/console --env=prod ezplatform:install demo && php ezpublish/console cache:clear --env=prod"
     fi
 }
 
 function warm_cache
 {
-    ${COMPOSE_EXECUTION_PATH}docker-compose -f $MAINCOMPOSE run --rm phpfpm1 /bin/bash -c "php ezpublish/console cache:warmup --env=prod"
+    ${COMPOSE_EXECUTION_PATH}docker-compose -f $MAINCOMPOSE run -u ez --rm phpfpm1 /bin/bash -c "php ezpublish/console cache:warmup --env=prod"
 }
 
 function create_distribution_tarball
@@ -200,7 +200,7 @@ function push_distribution_container
 
 function create_mysql_tarball
 {
-    ${COMPOSE_EXECUTION_PATH}docker-compose -f $MAINCOMPOSE run phpfpm1 /bin/bash -c "mysqldump -u ezp -p${MYSQL_PASSWORD} -h db --databases ezp > /tmp/ezp.sql"
+    ${COMPOSE_EXECUTION_PATH}docker-compose -f $MAINCOMPOSE run -u ez phpfpm1 /bin/bash -c "mysqldump -u ezp -p${MYSQL_PASSWORD} -h db --databases ezp > /tmp/ezp.sql"
     docker cp ${COMPOSE_PROJECT_NAME}_phpfpm1_run_1:/tmp/ezp.sql dockerfiles/databasedump
     docker rm ${COMPOSE_PROJECT_NAME}_phpfpm1_run_1
 }

--- a/docker-compose_behat.yml.template
+++ b/docker-compose_behat.yml.template
@@ -8,6 +8,7 @@ selenium:
 
 behatphpcli:
   image: ezsystems/ezphp
+  user: ez
   links:
    - db1:db
    - web1:web

--- a/docker-compose_ezpinstall.yml
+++ b/docker-compose_ezpinstall.yml
@@ -2,16 +2,18 @@ ezpublishvol:
   image: debian:jessie
   volumes:
    - ./volumes/ezpublish:/var/www
-  # Remove .keep file so composer is able to install in the directory afterwards
-  command: rm /var/www/.keep
+  # Remove .keep file so composer is able to install in the directory afterwards. UID=10000 and GUID=10000 is ez user in ezphp image
+  command: bash -c "rm /var/www/.keep; chown 10000:10000 /var/www"
 
 composercachevol:
   image: debian:jessie
   volumes:
    - ./volumes/composercache:/var/.composer/cache
+  command: chown 10000:10000 /var/.composer/cache
 
 ezphp:
   image: ezsystems/ezphp
+  user: ez
   volumes_from:
    - ezpublishvol
    - composercachevol

--- a/dockerfiles/distribution/Dockerfile
+++ b/dockerfiles/distribution/Dockerfile
@@ -1,6 +1,8 @@
 FROM debian:jessie
 
 add ezpublish.tar.gz /var/www
+# Make sure /var/www is also owned by ez user
+RUN chown 10000:10000 /var/www
 
 VOLUME [ "/var/www" ]
 

--- a/dockerfiles/ezphp/Dockerfile
+++ b/dockerfiles/ezphp/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update -q -y \
     vim \
     git \
     acl \
+    sudo \
     tree \
     && rm -rf /var/lib/apt/lists/*
 
@@ -75,6 +76,7 @@ ADD prepare_behat.sh /prepare_behat.sh
 ADD config/opcache.ini /etc/php5/mods-available/opcache.ini
 
 RUN chmod 755 /*.sh
+RUN groupadd -g 10000 ez && useradd -g ez -u 10000 ez
 
 WORKDIR /var/www
 

--- a/dockerfiles/ezphp/Dockerfile-dev
+++ b/dockerfiles/ezphp/Dockerfile-dev
@@ -39,6 +39,7 @@ RUN apt-get update -q -y \
     vim \
     git \
     acl \
+    sudo \
     tree \
     && rm -rf /var/lib/apt/lists/*
 
@@ -83,6 +84,7 @@ ADD config/opcache.ini /etc/php5/mods-available/opcache.ini
 ADD config/xdebug.ini /etc/php5/mods-available/xdebug.ini
 
 RUN chmod 755 /*.sh
+RUN groupadd -g 10000 ez && useradd -g ez -u 10000 ez
 
 WORKDIR /var/www
 

--- a/dockerfiles/ezphp/Dockerfile-php7
+++ b/dockerfiles/ezphp/Dockerfile-php7
@@ -31,6 +31,7 @@ RUN apt-get update -q -y \
         vim \
         git \
         acl \
+        sudo \
         tree \
         && rm -rf /var/lib/apt/lists/*
 
@@ -81,6 +82,7 @@ ADD prepare_behat.sh /prepare_behat.sh
 RUN sed -i "s@^exec /usr/sbin/php5-fpm@exec /usr/local/sbin/php-fpm@" /run.sh
 
 RUN chmod 755 /*.sh
+RUN groupadd -g 10000 ez && useradd -g ez -u 10000 ez
 
 WORKDIR /var/www
 

--- a/resources/motd_ez_welcome.conf
+++ b/resources/motd_ez_welcome.conf
@@ -39,10 +39,10 @@ Cli info:
 Examples:
 
   Run Symfony console commands:
-  $ docker exec -ti ezpublishdocker_phpfpm1_1 php ezpublish/console list
+  $ docker exec -u ez -ti ezpublishdocker_phpfpm1_1 php ezpublish/console list
 
   Composer update with new instance with same db/disk + mount composer cache volume:
-  $ docker run -ti --volumes-from=ezpublishdocker_composercachevol_1 \
+  $ docker run -u ez -ti --volumes-from=ezpublishdocker_composercachevol_1 \
                    --volumes-from=ezpublishdocker_ezpublishvol_1 \
                    --link=ezpublishdocker_db1_1:db \
                    ezpublishdocker_ezpphp:latest composer update


### PR DESCRIPTION
In order to make this a bit more secure, this PR changes so that:
 - PHP scripts are now executed as ez user

It also ensures that the .php files in the application itself are owned by ez, while www-data user has write access to folders on a need-to basis