### PR TITLE
Now builds both php5 and php7 image as eZ Publish 5.4 still requires php5

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Access the installation using the url http://33.33.33.53/
 
 #### Installing on local host without vagrant ( requires docker and docker-compose installed locally )
 
-Make a config file ( recommended, but not strictly speaking )
+Make a config file ( recommended, but not strictly speaking needed )
     ```cp files/docker-compose.config-EXAMPLE files/docker-compose.config```
 
 Create the service images ( web and php images )
@@ -249,7 +249,38 @@ Remove the containers:
     ```docker-compose -f docker-compose.yml rm -v; docker-compose -f docker-compose_ezpinstall.yml rm -v```
 
 Remove the images:
-    ```docker rmi ezsystems/web ezsystems/ezphp```
+    ```docker rmi ezsystems/web ezsystems/ezphp ezsystems/ezphp:5.6```
+
+Remove the eZ Platform files:
+    ```sudo rm -rf volumes/ezpublish/* volumes/mysql/*; sudo rm volumes/ezpublish/.travis.yml volumes/ezpublish/.gitignore```
+
+
+#### Installing ezp 5.4 on local host without vagrant ( requires docker and docker-compose installed locally )
+
+Make a config file ( recommended, but not strictly speaking needed )
+    ```cp files/docker-compose.config-EXAMPLE files/docker-compose.config```
+
+Make sure you have the following setting in ```files/docker-compose.config```:
+
+    EZ_COMPOSERPARAM="--prefer-dist --repository-url=https://updates.ez.no/ttl ezsystems/ezpublish-community /var/www ~5.4.0"
+
+Create the service images ( web and php images )
+    ```./build.sh```
+
+Install eZ Platform/Studio:
+    ```./docker-compose_ezpinstall.sh -f docker-compose_ezpinstall_php5.yml```
+
+Create the containers needed for running eZ Platform/Studio using php5 container instead of php7
+    ```./docker-compose.sh -f docker-compose.yml -f docker-compose_php5.yml up -d --no-recreate```
+
+Stop the containers:
+    ```docker-compose -f docker-compose.yml -f docker-compose_php5.yml stop```
+
+Remove the containers:
+    ```docker-compose -f docker-compose.yml -f docker-compose_php5.yml rm -v; docker-compose -f docker-compose_ezpinstall.yml -f docker-compose_php5.yml rm -v```
+
+Remove the images:
+    ```docker rmi ezsystems/web ezsystems/ezphp ezsystems/ezphp:5.6```
 
 Remove the eZ Platform files:
     ```sudo rm -rf volumes/ezpublish/* volumes/mysql/*; sudo rm volumes/ezpublish/.travis.yml volumes/ezpublish/.gitignore```

--- a/build.sh
+++ b/build.sh
@@ -35,12 +35,14 @@ function build
 function tag
 {
     docker tag -f ${COMPOSE_PROJECT_NAME}_web:latest ezsystems/web:latest
+    docker tag -f ${COMPOSE_PROJECT_NAME}_ezphp5:latest ezsystems/ezphp:5.6
     docker tag -f ${COMPOSE_PROJECT_NAME}_ezphp:latest ezsystems/ezphp:latest
 }
 
 function remove_project_tags
 {
     docker rmi ${COMPOSE_PROJECT_NAME}_web
+    docker rmi ${COMPOSE_PROJECT_NAME}_ezphp5
     docker rmi ${COMPOSE_PROJECT_NAME}_ezphp
 }
 

--- a/create_distro_containers.sh
+++ b/create_distro_containers.sh
@@ -13,6 +13,7 @@ set -e
 export COMPOSE_PROJECT_NAME=ezpublishdocker
 source files/distro_containers.config
 MAINCOMPOSE="docker-compose.yml"
+EZPINSTALLCOMPOSE=""
 DATE=`date +%Y%m%d`
 CONFIGFILE=""
 PUSH="false"
@@ -53,9 +54,10 @@ function parse_commandline_arguments
                     CONFIGFILE="$2"
                     shift
                     ;;
-#                -f* | --force )
-#                    FORCE=true
-#                    ;;
+                -e* | --ezp54 )
+                    EZPINSTALLCOMPOSE="-f docker-compose_ezpinstall_php5.yml"
+                    MAINCOMPOSE="$MAINCOMPOSE -f docker-compose_php5.yml"
+                    ;;
                 -p* | --push )
                     PUSH="true"
                     ;;
@@ -129,8 +131,8 @@ function prepare
     ${COMPOSE_EXECUTION_PATH}docker-compose -f docker-compose_databasedump.yml kill
     ${COMPOSE_EXECUTION_PATH}docker-compose -f docker-compose_databasedump.yml rm --force -v
 
-    ${COMPOSE_EXECUTION_PATH}docker-compose -f docker-compose_ezpinstall.yml kill
-    ${COMPOSE_EXECUTION_PATH}docker-compose -f docker-compose_ezpinstall.yml rm --force -v
+    ${COMPOSE_EXECUTION_PATH}docker-compose -f docker-compose_ezpinstall.yml $EZPINSTALLCOMPOSE kill
+    ${COMPOSE_EXECUTION_PATH}docker-compose -f docker-compose_ezpinstall.yml $EZPINSTALLCOMPOSE rm --force -v
     docker rmi ${COMPOSE_PROJECT_NAME}_ezpinstall || /bin/true
 
     docker rmi ${COMPOSE_PROJECT_NAME}_distribution:latest || /bin/true
@@ -156,9 +158,9 @@ function install_ezpublish
 {
     if [ $REBUILD_EZP == "true" ]; then
         if [ "$CONFIGFILE" == "" ]; then
-            ./docker-compose_ezpinstall.sh
+            ./docker-compose_ezpinstall.sh $EZPINSTALLCOMPOSE
         else
-            ./docker-compose_ezpinstall.sh -c $CONFIGFILE
+            ./docker-compose_ezpinstall.sh $EZPINSTALLCOMPOSE -c $CONFIGFILE
         fi
     else
         # Workaround since ezphp container is not defined in docker-compose.yml

--- a/create_distro_containers.sh
+++ b/create_distro_containers.sh
@@ -285,9 +285,6 @@ function pushonly
 echo parse_commandline_arguments
 parse_commandline_arguments "$@"
 
-echo getAppFolder:
-getAppFolder
-
 echo pushonly:
 pushonly
 
@@ -296,6 +293,9 @@ prepare
 
 echo install_ezpublish:
 install_ezpublish
+
+echo getAppFolder:
+getAppFolder
 
 echo run_installscript:
 run_installscript

--- a/docker-compose_build.yml
+++ b/docker-compose_build.yml
@@ -1,4 +1,7 @@
 
+ezphp5:
+  build: dockerfiles/ezphp
+
 ezphp:
   build: dockerfiles/ezphp
   dockerfile: Dockerfile-php7

--- a/docker-compose_ezpinstall.sh
+++ b/docker-compose_ezpinstall.sh
@@ -55,13 +55,13 @@ if [ "$EZ_ENVIRONMENT" = "dev" ]; then
     YMLFILE="docker-compose_ezpinstall_dev.yml"
 fi
 
-${COMPOSE_EXECUTION_PATH}docker-compose -f $YMLFILE up --no-recreate
+${COMPOSE_EXECUTION_PATH}docker-compose -f $YMLFILE $CMDPARAMETERS up --no-recreate
 
 # Unless user has provided install to use in volume folder, install from composer
 if [ ! -f volumes/ezpublish/composer.json ]; then
     echo "No prior install detected in ezpublish folder, so running Composer with: composer --no-interaction create-project ${EZ_COMPOSERPARAM?}"
-    ${COMPOSE_EXECUTION_PATH}docker-compose -f $YMLFILE run --rm ezphp composer --no-interaction create-project --no-progress ${EZ_COMPOSERPARAM?};
-    ${COMPOSE_EXECUTION_PATH}docker-compose -f $YMLFILE rm -v -f composercachevol ezphp
+    ${COMPOSE_EXECUTION_PATH}docker-compose -f $YMLFILE $CMDPARAMETERS run --rm ezphp composer --no-interaction create-project --no-progress ${EZ_COMPOSERPARAM?};
+    ${COMPOSE_EXECUTION_PATH}docker-compose -f $YMLFILE $CMDPARAMETERS rm -v -f composercachevol ezphp
 else
     echo "Prior install detected in ezpublish folder, skipp running Composer"
 fi

--- a/docker-compose_ezpinstall_php5.yml
+++ b/docker-compose_ezpinstall_php5.yml
@@ -1,0 +1,3 @@
+
+ezphp:
+  image: ezsystems/ezphp:5.6

--- a/docker-compose_php5.yml
+++ b/docker-compose_php5.yml
@@ -1,0 +1,3 @@
+
+phpfpm1:
+  image: ezsystems/ezphp:5.6

--- a/docker-compose_services_php5.yml
+++ b/docker-compose_services_php5.yml
@@ -1,0 +1,3 @@
+
+site1phpfpm1:
+  image: ezsystems/ezphp:5.6


### PR DESCRIPTION
After switching to php7, we still need to build php5 image in order to use eZ Publish 5.4