### PR TITLE
Fixed opcache so that ezp54 works again

### DIFF
--- a/dockerfiles/ezphp/config/opcache.ini
+++ b/dockerfiles/ezphp/config/opcache.ini
@@ -13,7 +13,6 @@ opcache.revalidate_freq=60
 opcache.enable_cli=1
 opcache.max_wasted_percentage=10
 ;opcache.fast_shutdown=1
-opcache.enable_file_override=1
 ; Comment out (enable) in eZ Publish 5.x installs which swaps cwd between symfony & legacy context
 opcache.use_cwd=0
 


### PR DESCRIPTION

```opcache.enable_file_override=1``` breakes ezp 5.4 ( After successfully running SW, you'll always be redireceted to /ezsetup again )

