### PR TITLE
Fixed so that cache cleaner is aware of environment variables thus re…

### DIFF
--- a/dockerfiles/ezphp/run.sh
+++ b/dockerfiles/ezphp/run.sh
@@ -79,7 +79,7 @@ if [ -d ezpublish ]; then
 fi
 
 echo "Clear cache after parameters where updated"
-sudo -u ez php $APP_FOLDER/console cache:clear --env $SYMFONY_ENV
+sudo -E -u ez php $APP_FOLDER/console cache:clear --env $SYMFONY_ENV
 
 if [ "$SYMFONY_ENV" != "dev" ]; then
     echo "Re-generate symlink assets in case rsync was used so asstets added during setup wizards are reachable"


### PR DESCRIPTION
Newly created demosites don't display recommendations due to missing environment variable upon cache clearing and warming up.

Since ezstudio-demo v1.4.0, ezstudio-demo-bundle conditionally includes `recommendations_header.html.twig` template which is responsible for loading ezrecommendation related assets (javascript files). In case of SDC, the condition relies on fact whether environment variable RECOMMENDATIONS_LICENSE_KEY is set or not.
Since the cache clearing script is executed as `ez` user, the environment variable is not available in its environment. The `-E` parameter fixes it (the quote from the man page of sudo):
```
-E, --preserve-env
             Indicates to the security policy that the user wishes to reserve their
             existing environment variables.  The security policy may eturn an error
             if the user does not have permission to preserve the environment.
```
