### PR TITLE
Do not display PHP errors

### DIFF
--- a/dockerfiles/ezphp/Dockerfile-php7
+++ b/dockerfiles/ezphp/Dockerfile-php7
@@ -55,6 +55,7 @@ RUN echo $TIMEZONE > /etc/timezone && dpkg-reconfigure --frontend noninteractive
 RUN echo "date.timezone = $TIMEZONE" >> /usr/local/etc/php/php.ini \
  && echo "memory_limit = $MEMORY_LIMIT" >> /usr/local/etc/php/php.ini \
  && echo "realpath_cache_size = 256k" >> /usr/local/etc/php/php.ini \
+ && echo "display_errors = Off" >> /usr/local/etc/php/php.ini \
  && echo "max_execution_time = $MAX_EXECUTION_TIME" >> /usr/local/etc/php/php.ini
 
 # Disable daemonizeing php-fpm


### PR DESCRIPTION
SDC/MDC demosites should not display PHP errors.