### PR TITLE
[Performance] Dump autoload to optimize class lookup

### DIFF
--- a/docker-compose_ezpinstall.sh
+++ b/docker-compose_ezpinstall.sh
@@ -61,6 +61,7 @@ ${COMPOSE_EXECUTION_PATH}docker-compose -f $YMLFILE $CMDPARAMETERS up --no-recre
 if [ ! -f volumes/ezpublish/composer.json ]; then
     echo "No prior install detected in ezpublish folder, so running Composer with: composer --no-interaction create-project ${EZ_COMPOSERPARAM?}"
     ${COMPOSE_EXECUTION_PATH}docker-compose -f $YMLFILE $CMDPARAMETERS run --rm ezphp composer --no-interaction create-project --no-progress ${EZ_COMPOSERPARAM?};
+    ${COMPOSE_EXECUTION_PATH}docker-compose -f $YMLFILE $CMDPARAMETERS run --rm ezphp composer dump-autoload --optimize;
     ${COMPOSE_EXECUTION_PATH}docker-compose -f $YMLFILE $CMDPARAMETERS run --rm ezphp bash -c "if [ -f /var/www/bin/vhost.sh ]; then chmod a+x /var/www/bin/vhost.sh; fi"
     ${COMPOSE_EXECUTION_PATH}docker-compose -f $YMLFILE $CMDPARAMETERS rm -v -f composercachevol ezphp
 else


### PR DESCRIPTION
Dumps a class array used to lookup classes ala eZ Publish legacy, if class is not found default dynamic file system loading is used instead. Speedup is typically around 5-10% on PHP 5.6 and higher where class map is placed in opcache memory, on lower version of PHP there will be a slight speed degradation because the class map needs to be loaded on each request.

Was planning to solve this in eZ Platform source code, however [QA found issue](https://jira.ez.no/browse/EZP-26839) with that so might have to fall back to instruct in doc to run it, and hence add it here as well.

Adding it here does not hurt no matter outcome in eZ Platofmr source, just some extra seconds spent during build.