### PR TITLE
EZEE-1710: Change Selenium version

### DIFF
--- a/docker-compose_behat.yml.template
+++ b/docker-compose_behat.yml.template
@@ -1,5 +1,5 @@
 selenium:
-  image: selenium/standalone-firefox
+  image: selenium/standalone-chrome-debug:3.4.0
   links:
    - web1:web
   ports:
@@ -9,6 +9,8 @@ selenium:
    - SCREEN_WIDTH=1920
    - SCREEN_HEIGHT=1080
    - SCREEN_DEPTH=24
+  # Because of: https://github.com/elgalu/docker-selenium/issues/20
+  shm_size: 256m
 
 behatphpcli:
   image: ezsystems/ezphp


### PR DESCRIPTION
> JIRA: [EZEE-1710](https://jira.ez.no/browse/EZEE-1710)

# Description

This PR introduces the same changes as in https://github.com/ezsystems/ezplatform/pull/203 to make sure our tests on Jenkins behave the same way as on Travis.

I've set shm_size to 256m, because my local tests showed that 128m is too low (I guess interacting with the Studio editor requires more resources). 256m should be enough.